### PR TITLE
library.properties architecture edit

### DIFF
--- a/ESP32WebServer/library.properties
+++ b/ESP32WebServer/library.properties
@@ -6,4 +6,4 @@ sentence=Simple web server library
 paragraph=The library supports HTTP GET and POST requests, provides argument parsing, handles one client at a time.
 category=Communication
 url=
-architectures=ESP32
+architectures=esp32


### PR DESCRIPTION
Architecture should be lowercase. All other esp32 libs use lowercase and now arduino IDE nags user about "Library may not be compatible"